### PR TITLE
Suggestion for adding MLHub link as dataset source

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Publication:
 
 In order to download MARIDA go to https://doi.org/10.5281/zenodo.5151941.
 
+Alternatively, MARIDA can be downloaded from the [Radiant MLHub](https://mlhub.earth/data/marida_v1). The `tar.gz` archive file downloaded from this source includes the STAC catalog associated with this dataset.
+
+
 ## Contents
 
 - [Installation](#installation)


### PR DESCRIPTION
Per suggestion by Hamed A., we would like to add a blurb with a link to the dataset now published on Radiant MLHub:

https://mlhub.earth/data/marida_v1